### PR TITLE
fix: MT798x 平台接口下拉无选项 - busybox 无 timeout 命令

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-pushbot
 PKG_VERSION:=5.12
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_MAINTAINER:=tty228 <tty228@yeah.net>  zzsj0928
 

--- a/ucode/controller/pushbot.uc
+++ b/ucode/controller/pushbot.uc
@@ -205,7 +205,7 @@ return {
 
 		/* network interfaces */
 		let ifaces = [];
-		let pf = popen("timeout 3 ls /sys/class/net 2>/dev/null", "r");
+		let pf = popen("ls /sys/class/net 2>/dev/null", "r");
 		if (pf) {
 			for (let line = pf.read("line"); line; line = pf.read("line")) {
 				let n = replace(line, /\s+/, "");
@@ -218,7 +218,7 @@ return {
 
 		/* IP hints from arp */
 		let ip_hints = [];
-		let arpf = popen("timeout 3 grep -E '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+' /proc/net/arp 2>/dev/null", "r");
+		let arpf = popen("grep -E '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+' /proc/net/arp 2>/dev/null", "r");
 		if (arpf) {
 			for (let line = arpf.read("line"); line; line = arpf.read("line")) {
 				let m = match(line, /^(\d+\.\d+\.\d+\.\d+)/);
@@ -241,7 +241,7 @@ return {
 			lf.close();
 		}
 		/* also try arp for additional MACs */
-		let arpf2 = popen("timeout 3 grep -E '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+' /proc/net/arp 2>/dev/null", "r");
+		let arpf2 = popen("grep -E '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+' /proc/net/arp 2>/dev/null", "r");
 		if (arpf2) {
 			for (let line = arpf2.read("line"); line; line = arpf2.read("line")) {
 				let m = match(line, /^(\d+\.\d+\.\d+\.\d+)\s+\S+\s+\S+\s+(\S+)/);

--- a/ucode/template/pushbot/pushbot_status.ut
+++ b/ucode/template/pushbot/pushbot_status.ut
@@ -3676,7 +3676,7 @@ window.addEventListener('load',function(){apply(compute());});
 				</div>
 			</div>
 		</div>
-		<span class="pushbot-version-badge">v5.12-r7</span>
+		<span class="pushbot-version-badge">v5.12-r8</span>
 		<div id="pushbot_status_badge" class="pushbot-status-badge is-stopped" role="status" aria-live="polite">
 			<span class="pushbot-status-dot"></span>
 			<span id="pushbot_status_text">{{ _('NOT RUNNING') }}</span>


### PR DESCRIPTION
- controller 3 处 popen("timeout 3 ...") 去掉 timeout
- timeout 在部分自编译固件(busybox 未启用)不存在, 导致 ls /sys/class/net 输出为空, 接口下拉无选项
- sysfs/proc 本地读取即时返回, 无需 timeout