### PR TITLE
build: move override VERSION before include luci.mk (5.12-r10)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,18 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-pushbot
 PKG_VERSION:=5.12
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 
 PKG_MAINTAINER:=tty228 <tty228@yeah.net>  zzsj0928
+
+# OpenWrt 23.05 的 luci.mk 版本规则只取 PKG_VERSION（忽略 PKG_RELEASE），
+# 导致 GitHub Action 编译出的 ipk 没有 r 小版本（5.12 vs 5.12-r10）。
+# 用 override VERSION 强制统一为 PKG_VERSION-rPKG_RELEASE。注意：必须
+# 写在 include luci.mk 之前——luci.mk 末尾会立即 eval BuildPackage，
+# 其 ipk 命名/control 里的 $(VERSION) 在那一刻固化，写后面就晚了。
+# luci.mk 的 VERSION:= 是普通赋值（被 override 压住），且本值在新版
+# luci.mk 与 i18n 子包（PKG_PO_VERSION）下与默认一致，不影响 apk/新版。
+override VERSION:=$(if $(PKG_RELEASE),$(PKG_VERSION)-r$(PKG_RELEASE),$(PKG_VERSION))
 
 LUCI_TITLE:=LuCI support for Pushbot
 LUCI_PKGARCH:=all
@@ -21,12 +30,5 @@ define Package/$(PKG_NAME)/conffiles
 endef
 
 include $(TOPDIR)/feeds/luci/luci.mk
-
-# OpenWrt 23.05 的 luci.mk 版本规则只取 PKG_VERSION（忽略 PKG_RELEASE），
-# 导致 GitHub Action 编译出的 ipk 没有 r 小版本（5.12 vs 5.12-r8）。
-# 用 override VERSION 强制统一为 PKG_VERSION-rPKG_RELEASE：luci.mk 的
-# VERSION:= 是普通赋值（会被 override 压住），且本值在新版 luci.mk 与
-# i18n 子包（PKG_PO_VERSION）下与默认一致，所有 OpenWrt 版本输出相同。
-override VERSION:=$(if $(PKG_RELEASE),$(PKG_VERSION)-r$(PKG_RELEASE),$(PKG_VERSION))
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/ucode/template/pushbot/pushbot_status.ut
+++ b/ucode/template/pushbot/pushbot_status.ut
@@ -3676,7 +3676,7 @@ window.addEventListener('load',function(){apply(compute());});
 				</div>
 			</div>
 		</div>
-		<span class="pushbot-version-badge">v5.12-r9</span>
+		<span class="pushbot-version-badge">v5.12-r10</span>
 		<div id="pushbot_status_badge" class="pushbot-status-badge is-stopped" role="status" aria-live="polite">
 			<span class="pushbot-status-dot"></span>
 			<span id="pushbot_status_text">{{ _('NOT RUNNING') }}</span>


### PR DESCRIPTION
- 同 luci-theme-liquid bd90826: 68ec44c 位置错误, override 放 include 后太晚
- luci.mk 末尾立即 eval BuildPackage, ipk 命名/control 的 $(VERSION) 在那一刻固化
- override VERSION 移到 include 之前, 23.05 ipk 才有 r 小版本