### PR TITLE
修复pushbot.uc中crul相关type变量名为ip_type

### DIFF
--- a/ucode/controller/pushbot.uc
+++ b/ucode/controller/pushbot.uc
@@ -200,8 +200,8 @@ return {
 				let start = time() % length(lines);
 				for (let i = 0; i < 3 && i < length(lines); i++) {
 					let pick = lines[(start + i) % length(lines)];
-					let out = run("curl -k -s -" + (type == "4" ? "4" : "6") + bind + " -m 8 " + sq(pick) +
-						(type == "4"
+					let out = run("curl -k -s -" + (ip_type == "4" ? "4" : "6") + bind + " -m 8 " + sq(pick) +
+						(ip_type == "4"
 							? " | grep -oE '[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}' | head -n1"
 							: " | grep -oE '([\\da-fA-F0-9]{1,4}(:{1,2})){1,15}[\\da-fA-F0-9]{1,4}' | head -n1"));
 					if (out != "") { ip = out; break; }


### PR DESCRIPTION
修复curl获取ip变量名