### PR TITLE
修复黑名单到期同步和旧页面回写问题

### DIFF
--- a/root/usr/bin/pushbot/pushbot
+++ b/root/usr/bin/pushbot/pushbot
@@ -16,7 +16,7 @@ function read_config(){
 	"pushbot_ipv4" "ipv4_interface" "pushbot_ipv6" "ipv6_interface" "pushbot_up" "pushbot_down" "cpuload_enable" "cpuload" "temperature_enable" "temperature" \
 	"regular_time" "regular_time_2" "regular_time_3" "interval_time" "crontab" \
 	"client_usage" "client_usage_max" "client_usage_disturb" "client_usage_whitelist" \
-	"web_logged" "ssh_logged" "web_login_failed" "ssh_login_failed" "wifi_connected" "wifi_auth_failed" "login_max_num" "web_login_black" "ip_white_list" "ip_black_timeout" \
+	"web_logged" "ssh_logged" "web_login_failed" "ssh_login_failed" "wifi_connected" "wifi_auth_failed" "login_max_num" "web_login_black" "ip_white_list" "ip_black_timeout" "ip_black_persist" \
 	"pushbot_sheep" "starttime" "endtime" "pushbot_whitelist" "pushbot_blacklist" "pushbot_interface" "MAC_online_list" "MAC_offline_list" \
 	"dnd_low_range" \
 	"up_timeout" "down_timeout" "timeout_retry_count" "thread_num" "soc_code" "pve_host" "pve_port"\

--- a/root/usr/bin/pushbot/pushbot
+++ b/root/usr/bin/pushbot/pushbot
@@ -1558,8 +1558,7 @@ function login_send(){
 					sed -i "/^${login_ip}$/d" ${dir}web_failed
 					echo "`date "+%Y-%m-%d %H:%M:%S"` 【！！！】设备 ${login_ip} 通过 Web 频繁尝试登录" >> ${logfile}
 				else
-					echo "`date "+%Y-%m-%d %H:%M:%S"` 【！！！】设备 ${login_ip} 触发拉黑但被本机/白名单保护拦截，保留记录待后续确认" >> ${logfile}
-				fi
+					echo "`date "+%Y-%m-%d %H:%M:%S"` 【！！！】设备 ${login_ip} 触发拉黑但未成功，保留记录待后续确认" >> ${logfile}				fi
 			fi
 		fi
 	done
@@ -2104,14 +2103,20 @@ function need_blacklist_sync(){
 		[ ! -f "${ip_blacklist_path}" ] && return 0
 	fi
 
-	# 检查 4：内核 set 缺失（fw4 重启/路由重启清空了 nft set）
-	# 只在 set 为空时才需要同步（set 非空说明规则已生效，不需要重复执行）
+	# 检查 4：集合或 DROP 规则缺失；保留空集合触发到期对账
 	if [ "$cur_onoff" = "1" ] && [ -s "${ip_blacklist_path}" ]; then
 		if command -v nft >/dev/null 2>&1; then
-			local set_count=$(nft list set inet fw4 pushbot_blacklist 2>/dev/null | grep -c "elements = {" || echo "0")
-			if [ "$set_count" -eq "0" ]; then
-				return 0
-			fi
+			local set4 input_rules
+			set4=$(nft list set inet fw4 pushbot_blacklist 2>/dev/null) || return 0
+			nft list set inet fw4 pushbot_blacklist6 >/dev/null 2>&1 || return 0
+			input_rules=$(nft list chain inet fw4 input 2>/dev/null) || return 0
+
+			printf '%s\n' "$input_rules" |
+				grep -qE '^[[:space:]]*ip saddr @pushbot_blacklist[[:space:]]+drop([[:space:]]|$)' || return 0
+			printf '%s\n' "$input_rules" |
+				grep -qE '^[[:space:]]*ip6 saddr @pushbot_blacklist6[[:space:]]+drop([[:space:]]|$)' || return 0
+
+			printf '%s\n' "$set4" | grep -qF 'elements = {' || return 0
 		fi
 	fi
 
@@ -2221,9 +2226,15 @@ function add_ip_black(){
 	# 直接查内核：拉黑开启且有 IP 时，set 或 rule 缺失即强制重建。
 	if ! $need_update && [ -n "$cur_onoff" ] && [ "$cur_onoff" != "0" ] && [ -s "${ip_blacklist_path}" ]; then
 		if command -v nft >/dev/null 2>&1; then
+			local input_rules
 			nft list set inet fw4 pushbot_blacklist >/dev/null 2>&1 || need_update=true
 			nft list set inet fw4 pushbot_blacklist6 >/dev/null 2>&1 || need_update=true
-			grep "@pushbot_blacklist" | grep -v "@pushbot_blacklist6" | grep -q . || need_update=true
+			input_rules=$(nft list chain inet fw4 input 2>/dev/null) || need_update=true
+
+			printf '%s\n' "$input_rules" |
+				grep -qE '^[[:space:]]*ip saddr @pushbot_blacklist[[:space:]]+drop([[:space:]]|$)' || need_update=true
+			printf '%s\n' "$input_rules" |
+				grep -qE '^[[:space:]]*ip6 saddr @pushbot_blacklist6[[:space:]]+drop([[:space:]]|$)' || need_update=true
 		else
 			ipset list ip_blacklist >/dev/null 2>&1 || need_update=true
 			iptables -C INPUT -m set --match-set ip_blacklist src -j DROP >/dev/null 2>&1 || need_update=true
@@ -2351,11 +2362,23 @@ function add_ip_black(){
 			nft add set inet fw4 pushbot_blacklist6 { type ipv6_addr\; timeout ${bl_timeout_sec}s\; } 2>/dev/null || true
 		fi
 		# 规则用 insert（链首优先，不被 accept 抢先），且只在缺失时插入
-		if ! nft list chain inet fw4 input 2>/dev/null | grep "@pushbot_blacklist" | grep -v "@pushbot_blacklist6" | grep -q .; then
-			nft insert rule inet fw4 input ip saddr @pushbot_blacklist drop 2>/dev/null || true
+		local input_rules
+		input_rules=$(nft list chain inet fw4 input 2>/dev/null) || input_rules=""
+
+		if ! printf '%s\n' "$input_rules" |
+			grep -qE '^[[:space:]]*ip saddr @pushbot_blacklist[[:space:]]+drop([[:space:]]|$)'; then
+			if ! nft insert rule inet fw4 input ip saddr @pushbot_blacklist drop 2>>"$logfile"; then
+				echo "$(date '+%Y-%m-%d %H:%M:%S') 【防火墙】【失败】IPv4 黑名单 DROP 规则插入失败" >> "$logfile"
+				return 1
+			fi
 		fi
-		if ! nft list chain inet fw4 input 2>/dev/null | grep -q "@pushbot_blacklist6"; then
-			nft insert rule inet fw4 input ip6 saddr @pushbot_blacklist6 drop 2>/dev/null || true
+
+		if ! printf '%s\n' "$input_rules" |
+			grep -qE '^[[:space:]]*ip6 saddr @pushbot_blacklist6[[:space:]]+drop([[:space:]]|$)'; then
+			if ! nft insert rule inet fw4 input ip6 saddr @pushbot_blacklist6 drop 2>>"$logfile"; then
+				echo "$(date '+%Y-%m-%d %H:%M:%S') 【防火墙】【失败】IPv6 黑名单 DROP 规则插入失败" >> "$logfile"
+				return 1
+			fi
 		fi
 		# 增量同步：不 flush 重建（会抹掉内核超时状态），只补齐 set 缺失元素。
 		# 文件是"待拉黑"登记，set 是"生效中"权威（含 timeout，到期自动移除）。

--- a/ucode/controller/pushbot.uc
+++ b/ucode/controller/pushbot.uc
@@ -1,7 +1,7 @@
 // Copyright 2022-2025 tty228 <tty228@yeah.net> zzsj0928
 // Licensed to the public under the Apache License 2.0.
 
-import { popen, open, readfile } from 'fs';
+import { popen, open, readfile, access, mkdir } from 'fs';
 import { cursor } from 'uci';
 import { translate } from 'luci.core';
 
@@ -21,7 +21,15 @@ function sq(s) {
 
 /* ── helper: uci commit ── */
 function uci_commit(conf) {
-	system("/sbin/uci -q commit " + conf);
+	return system("/sbin/uci -q commit " + conf);
+}
+
+/* 与主程序一致：永久且开启持久化才使用持久文件。 */
+function ip_blacklist_path(timeout, persist) {
+	if (persist == null || persist == "" || persist == "undefined" || persist == "null")
+		persist = "1";
+	return "" + (timeout ?? "") == "0" && "" + persist == "1"
+		? "/usr/bin/pushbot/api/ip_blacklist" : "/tmp/pushbot/ip_blacklist";
 }
 
 return {
@@ -334,7 +342,7 @@ return {
 			diy_json:    "/usr/bin/pushbot/api/diy.json",
 			ipv4_list:   "/usr/bin/pushbot/api/ipv4.list",
 			ipv6_list:   "/usr/bin/pushbot/api/ipv6.list",
-			ip_black_list: "/usr/bin/pushbot/api/ip_blacklist"
+			ip_black_list: ip_blacklist_path(section.ip_black_timeout, section.ip_black_persist)
 		};
 
 		/* 黑名单对账由主进程定时同步（login_send + 主循环），页面加载时不触发
@@ -478,12 +486,85 @@ return {
 			return;
 		}
 
+		/* 先合并本次设置再选路径，不依赖 JSON 字段遍历顺序。 */
+		let previous = cursor().get_all("pushbot", "pushbot") ?? {};
+		if ("ip_black_persist" in data) {
+			let p = data.ip_black_persist;
+			if (p == null || p == "" || p == "undefined" || p == "null") p = "1";
+			if (p != "0" && p != "1") {
+				http.write_json({ ok: false, error: "invalid ip_black_persist" });
+				return;
+			}
+			data.ip_black_persist = "" + p;
+		}
+		if ("ip_black_timeout" in data && data.ip_black_timeout != null && type(data.ip_black_timeout) != "string") {
+			http.write_json({ ok: false, error: "invalid ip_black_timeout" });
+			return;
+		}
+		let old_path = ip_blacklist_path(previous.ip_black_timeout, previous.ip_black_persist);
+		let new_path = ip_blacklist_path(
+			"ip_black_timeout" in data ? data.ip_black_timeout : previous.ip_black_timeout,
+			"ip_black_persist" in data ? data.ip_black_persist : previous.ip_black_persist);
+		/* 未提交名单而切换路径时，只迁移旧活动名单；空名单也覆盖目标。 */
+		if (!("ip_black_list" in data) && old_path != new_path) {
+			let old_list = readfile(old_path);
+			if (old_list == null) {
+				http.write_json({ ok: false, error: "cannot read active IP blacklist" });
+				return;
+			}
+			data.ip_black_list = old_list;
+		}
+		if ("ip_black_list" in data && type(data.ip_black_list) != "string") {
+			http.write_json({ ok: false, error: "invalid ip_black_list" });
+			return;
+		}
+
 		let file_paths = {
 			diy_json: "/usr/bin/pushbot/api/diy.json",
 			ipv4_list: "/usr/bin/pushbot/api/ipv4.list",
 			ipv6_list: "/usr/bin/pushbot/api/ipv6.list",
-			ip_black_list: "/usr/bin/pushbot/api/ip_blacklist"
+			ip_black_list: new_path
 		};
+
+		/* 先写文件并检查结果；失败时不继续提交配置或启动服务。 */
+		for (let opt, path in file_paths) {
+			if (!(opt in data)) continue;
+			let content = type(data[opt]) == "string" ? data[opt] : "";
+			if (opt == "ip_black_list") {
+				let keep = [];
+				let seen = {};
+				let loc = { "::1": true, "127.0.0.1": true };
+				let pf = popen("ip -o addr show 2>/dev/null | awk '{print $4}' | cut -d/ -f1", "r");
+				if (pf) {
+					for (let line = pf.read("line"); line; line = pf.read("line")) {
+						let a = replace(line, /[\r\n\s]+/, "");
+						if (a != "") loc[a] = true;
+					}
+					pf.close();
+				}
+				for (let p in split(content, /\s+/)) {
+					if (p == "" || (p in loc) || (p in seen)) continue;
+					seen[p] = true;
+					push(keep, p);
+				}
+				content = length(keep) ? join("\n", keep) + "\n" : "";
+				if (path == "/tmp/pushbot/ip_blacklist" && !access("/tmp/pushbot") && !mkdir("/tmp/pushbot")) {
+					http.write_json({ ok: false, error: "cannot create /tmp/pushbot" });
+					return;
+				}
+			}
+			let f = open(path, "w");
+			if (!f) {
+				http.write_json({ ok: false, error: "cannot open " + path });
+				return;
+			}
+			let written = f.write(content);
+			let closed = f.close();
+			if (written !== length(content) || !closed) {
+				http.write_json({ ok: false, error: "cannot write " + path });
+				return;
+			}
+		}
 
 		let list_opt_set = {
 			device_aliases: true,
@@ -509,6 +590,7 @@ return {
 		}
 
 		for (let opt, val in data) {
+			if (opt in file_paths) continue;
 			/* color options: only #RRGGBB */
 			if (opt in font_opts) {
 				if (type(val) != 'string' || val == "" || !match(val, /^#[0-9a-fA-F]{6}$/))
@@ -516,48 +598,6 @@ return {
 				else {
 					uci_cmd("delete", "pushbot.pushbot." + sq(opt));
 					uci_cmd("set", "pushbot.pushbot." + sq(opt) + "=" + sq(val));
-				}
-			}
-			/* file paths */
-			else if (opt in file_paths) {
-				let path = file_paths[opt];
-				if (type(val) == 'string' && val != "") {
-					/* 黑名单文件：支持换行/空格/tab 混合分隔（与脚本端
-					   IFS 空白分割一致），保存时统一规范为每行一个 IP */
-					if (opt == "ip_black_list") {
-						let keep = [];
-						let seen = {};
-						let loc = { "::1": true, "127.0.0.1": true };
-						let pf = popen("ip -o addr show 2>/dev/null | awk '{print $4}' | cut -d/ -f1", "r");
-						if (pf) {
-							for (let line = pf.read("line"); line; line = pf.read("line")) {
-								let a = replace(line, /[\r\n\s]+/, "");
-								if (a != "")
-									loc[a] = true;
-							}
-							pf.close();
-						}
-						/* 按任意空白分割（换行/空格/tab 混用均可） */
-						let parts = split(replace(val, /\r\n/g, "\n"), /\s+/);
-						for (let p in parts) {
-							let l = replace(p, /[\r\n\s]+/, "");
-							if (l == "" || (l in loc) || (l in seen))
-								continue;
-							seen[l] = true;
-							push(keep, l);
-						}
-						content = join("\n", keep);
-						if (length(content) > 0)
-							content += "\n";
-					}
-					/* 非黑名单文件（diy.json / ipv4.list / ipv6.list）直接写原始值；
-					   黑名单分支已构造规范化 content，两者共用此行 */
-					let f = open(path, "w");
-					if (f) { f.write(content ?? val); f.close(); }
-				}
-				else {
-					let f = open(path, "w");
-					if (f) { f.write(""); f.close(); }
 				}
 			}
 			/* list options */
@@ -612,7 +652,10 @@ return {
 				}
 			}
 		}
-		uci_commit("pushbot");
+		if (uci_commit("pushbot") != 0) {
+			http.write_json({ ok: false, error: "cannot commit pushbot configuration" });
+			return;
+		}
 
 		/* 保存后联动服务状态（避免"config 启用但服务未启动"）：
 		 *   enable=1 → 服务未跑则启动，已在跑则重启使新配置生效

--- a/ucode/template/pushbot/pushbot_status.ut
+++ b/ucode/template/pushbot/pushbot_status.ut
@@ -1993,8 +1993,8 @@ cuSub.appendChild(mkBtn('{{ _('Traffic DND') }}',cdOn,function(on){updateFlagInp
 	
 	/* 黑名单持久化按钮（仅在拉黑时间=永久时显示） */
 	var banPersistDiv = document.createElement('div'); banPersistDiv.style.cssText = 'margin:4px 0';
-	var banPersistHi = mkH('ip_black_persist', CT_BAN_PERSIST);
 	var CT_BAN_PERSIST = PB_val('ip_black_persist', '1') !== '0';
+	var banPersistHi = mkH('ip_black_persist', CT_BAN_PERSIST ? '1' : '0');
 	var banPersistBtn = mkBtn('{{ _('Blacklist persist') }}', CT_BAN_PERSIST, function(on) {
 		banPersistHi.value = on ? '1' : '0';
 	});
@@ -3465,14 +3465,10 @@ function loadLog() {
 /* ═══════════════════════════════════════════ */
 /* ── Collect hidden input data from all containers ── */
 window.__pbCollectData = function() {
-	/* 收集前强制同步 textarea → hidden（防 input 事件缺失导致保存值丢失/null） */
-	document.querySelectorAll('textarea').forEach(function(ta) {
-		var hid = null;
-		document.querySelectorAll('input[type="hidden"]').forEach(function(inp) {
-			if (inp.name && inp.name.indexOf('ip_black_list') >= 0) hid = inp;
-		});
-		if (hid) hid.value = ta.value;
-	});
+	/* 收集前只同步 IP 黑名单，避免被其他 textarea 覆盖 */
+	var banTa = document.querySelector('#ct_ban_sub textarea');
+	var banHi = document.querySelector('[name="cbid.pushbot.pushbot.ip_black_list"]');
+	if (banTa && banHi) banHi.value = banTa.value;
 	var ids = ['pushbot_hidden_fields','con_hidden_fields','mon_hidden_fields','term_hidden_fields','disturb_hidden_fields'];
 	var data = {};
 	ids.forEach(function(id) {


### PR DESCRIPTION
基于 #225、#226。

修复部分 IPv4/IPv6 到期未清理、同轮增删被覆盖、旧页面保存回写过期名单。读取或更新失败不记录成功，保存失败不继续发送测试消息。

复用现有状态和临时文件，不处理 reload 后的剩余时长恢复。

已通过 nft 隔离测试、ipset 模拟测试及前端、控制器回归。